### PR TITLE
12/24h bit is wrong

### DIFF
--- a/RtcUtility.cpp
+++ b/RtcUtility.cpp
@@ -21,10 +21,10 @@ uint8_t Uint8ToBcd(uint8_t val)
 uint8_t BcdToBin24Hour(uint8_t bcdHour)
 {
     uint8_t hour;
-    if (bcdHour & 0x20)
+    if (bcdHour & 0x40)
     {
         // 12 hour mode, convert to 24
-        bool isPm = ((bcdHour & 0x10) != 0);
+        bool isPm = ((bcdHour & 0x20) != 0);
 
         hour = BcdToUint8(bcdHour & 0x1f);
         if (isPm)


### PR DESCRIPTION
In the BcdToBin24Hour function the 5th bit is being checked as the 12/24h bit. However, this is the AM/PM bit if the 12h mode is set. The correct it is 6, thus it shoukd be compares to 0x40 and 0x20 at lines 24 and 27 respectively.