### PR TITLE
Remove compiler warnings

### DIFF
--- a/src/RtcDS3231.h
+++ b/src/RtcDS3231.h
@@ -76,12 +76,12 @@ public:
     }
 
 protected:
-    uint8_t _second;
-    uint8_t _minute;
-    uint8_t _hour;
-    uint8_t _dayOf;
-
     DS3231AlarmOneControl _flags;
+
+	uint8_t _dayOf;
+	uint8_t _hour;
+	uint8_t _minute;
+    uint8_t _second;  
 };
 
 // minutes accuracy
@@ -143,11 +143,11 @@ public:
     }
 
 protected:
-    uint8_t _minute;
-    uint8_t _hour;
-    uint8_t _dayOf;
-
     DS3231AlarmTwoControl _flags;
+
+	uint8_t _dayOf;
+	uint8_t _hour;
+	uint8_t _minute;
 };
 
 


### PR DESCRIPTION
Seems stupid, but the compiler doesn't like the order of the declared variables.
If you define variables A and B, you have to call the constructor with CONSTRUCTOR():A(x),B(y) and not CONSTRUCTOR():B(y),A(x).

RtcDS3231.h: In constructor 'DS3231AlarmTwo::DS3231AlarmTwo(uint8_t, uint8_t, uint8_t, DS3231Ala...
RtcDS3231.h:149:10: warning:   'uint8_t DS3231AlarmTwo::_minute' [-Wreorder]  uint8_t _minute;