### PR TITLE
Better cross platform support

### DIFF
--- a/library.json
+++ b/library.json
@@ -7,7 +7,7 @@
     "type": "git",
     "url": "https://github.com/Makuna/Rtc.git"
   },
-  "version": "2.0.0",
+  "version": "2.0.1",
   "frameworks": "arduino",
   "platforms": "*"
 }

--- a/library.properties
+++ b/library.properties
@@ -1,9 +1,9 @@
 name=Rtc by Makuna
-version=2.0.0
+version=2.0.1
 author=Michael C. Miller (makuna@live.com)
 maintainer=Michael C. Miller (makuna@live.com)
 sentence=A library that makes interfacing DS1307 and DS3231 Real Time Clock modules easy.
 paragraph=Includes deep support of module features, including temperature, alarms and memory storage if present.  Tested on esp8266.
 category=Device Control
-url=https://github.com/Makuna/Rtc
+url=https://github.com/Makuna/Rtc/wiki
 architectures=*

--- a/src/RtcDS1307.h
+++ b/src/RtcDS1307.h
@@ -16,6 +16,7 @@ const uint8_t DS1307_REG_STATUS     = 0x00;
 const uint8_t DS1307_REG_CONTROL    = 0x07;
 const uint8_t DS1307_REG_RAMSTART   = 0x08;
 const uint8_t DS1307_REG_RAMEND     = 0x3f;
+const uint8_t DS1307_REG_RAMSIZE = DS1307_REG_RAMEND - DS1307_REG_RAMSTART;
 
 //DS1307 Register Data Size if not just 1
 const uint8_t DS1307_REG_TIMEDATE_SIZE = 7;
@@ -163,7 +164,11 @@ public:
         uint8_t countRead = 0;
         if (address <= DS1307_REG_RAMEND)
         {
-            countBytes = min(countBytes, DS1307_REG_RAMEND - DS1307_REG_RAMSTART);
+            if (countBytes > DS1307_REG_RAMSIZE)
+            {
+                countBytes = DS1307_REG_RAMSIZE;
+            }
+
             _wire.beginTransmission(DS1307_ADDRESS);
             _wire.write(address);
             _wire.endTransmission();

--- a/src/RtcUtility.h
+++ b/src/RtcUtility.h
@@ -2,6 +2,11 @@
 #ifndef __RTCUTILITY_H__
 #define __RTCUTILITY_H__
 
+// for some reason, the DUE board support does not define this, even though other non AVR archs do
+#ifndef _BV
+#define _BV(b) (1UL << (b))
+#endif
+
 extern uint8_t BcdToUint8(uint8_t val);
 extern uint8_t Uint8ToBcd(uint8_t val);
 extern uint8_t BcdToBin24Hour(uint8_t bcdHour);


### PR DESCRIPTION
remove the use of min as the macro collides with other libraries.
add a bit vector macro due to some non-avr platforms do not include it