### PR TITLE
DS1307 (8PDIP) , ESP8266 and One Wire

### DIFF
--- a/examples/DS1307_Simple/DS1307_Simple.ino
+++ b/examples/DS1307_Simple/DS1307_Simple.ino
@@ -34,11 +34,11 @@ void setup ()
     Serial.println(__TIME__);
 
     //--------RTC SETUP ------------
-    Rtc.Begin();
-
     // if you are using ESP-01 then uncomment the line below to reset the pins to
     // the available pins for SDA, SCL
     // Wire.begin(0, 2); // due to limited pins, use pin 0 and 2 for SDA, SCL
+ 
+    Rtc.Begin();
 
     RtcDateTime compiled = RtcDateTime(__DATE__, __TIME__);
     printDateTime(compiled);


### PR DESCRIPTION
I have making some test since I opened the Issue #5. Using the DS1307 (8PDIP) with the ESP8266, the Wire.begin() must be called before the Rtc.begin() otherwise the DS1307 won't be started and won't increase the time.