### PR TITLE
Fixed examples with One Wire and RTC's beginning correct order

### DIFF
--- a/examples/DS1307_Memory/DS1307_Memory.ino
+++ b/examples/DS1307_Memory/DS1307_Memory.ino
@@ -39,11 +39,11 @@ void setup ()
     Serial.println(__TIME__);
 
     //--------RTC SETUP ------------
-    Rtc.Begin();
-
     // if you are using ESP-01 then uncomment the line below to reset the pins to
     // the available pins for SDA, SCL
     // Wire.begin(0, 2); // due to limited pins, use pin 0 and 2 for SDA, SCL
+    
+    Rtc.Begin();
 
     RtcDateTime compiled = RtcDateTime(__DATE__, __TIME__);
     printDateTime(compiled);

--- a/examples/DS1307_Simple/DS1307_Simple.ino
+++ b/examples/DS1307_Simple/DS1307_Simple.ino
@@ -34,11 +34,11 @@ void setup ()
     Serial.println(__TIME__);
 
     //--------RTC SETUP ------------
-    Rtc.Begin();
-
     // if you are using ESP-01 then uncomment the line below to reset the pins to
     // the available pins for SDA, SCL
     // Wire.begin(0, 2); // due to limited pins, use pin 0 and 2 for SDA, SCL
+    
+    Rtc.Begin();
 
     RtcDateTime compiled = RtcDateTime(__DATE__, __TIME__);
     printDateTime(compiled);

--- a/examples/DS3231_Alarms/DS3231_Alarms.ino
+++ b/examples/DS3231_Alarms/DS3231_Alarms.ino
@@ -65,10 +65,11 @@ void setup ()
     pinMode(RtcSquareWavePin, INPUT);
 
     //--------RTC SETUP ------------
-    Rtc.Begin();
     // if you are using ESP-01 then uncomment the line below to reset the pins to
     // the available pins for SDA, SCL
     // Wire.begin(0, 2); // due to limited pins, use pin 0 and 2 for SDA, SCL
+    
+    Rtc.Begin();
 
     RtcDateTime compiled = RtcDateTime(__DATE__, __TIME__);
 

--- a/examples/DS3231_Simple/DS3231_Simple.ino
+++ b/examples/DS3231_Simple/DS3231_Simple.ino
@@ -35,11 +35,11 @@ void setup ()
     Serial.println(__TIME__);
 
     //--------RTC SETUP ------------
-    Rtc.Begin();
-
     // if you are using ESP-01 then uncomment the line below to reset the pins to
     // the available pins for SDA, SCL
     // Wire.begin(0, 2); // due to limited pins, use pin 0 and 2 for SDA, SCL
+    
+    Rtc.Begin();
 
     RtcDateTime compiled = RtcDateTime(__DATE__, __TIME__);
     printDateTime(compiled);

--- a/examples/DS3231_StoreIt/DS3231_StoreIt.ino
+++ b/examples/DS3231_StoreIt/DS3231_StoreIt.ino
@@ -35,10 +35,11 @@ void setup ()
     Serial.println(__TIME__);
 
     //--------RTC SETUP ------------
-    Rtc.Begin();
     // if you are using ESP-01 then uncomment the line below to reset the pins to
     // the available pins for SDA, SCL
     // Wire.begin(0, 2); // due to limited pins, use pin 0 and 2 for SDA, SCL
+    
+    Rtc.Begin();
 
     RtcDateTime compiled = RtcDateTime(__DATE__, __TIME__);
     printDateTime(compiled);


### PR DESCRIPTION
Wire.begin() must be called before the Rtc.begin() otherwise the RTC won't be started and won't increase the time.
