### PR TITLE
Add support for ESP32 and - operator on RtcDateTime

### DIFF
--- a/src/RtcDateTime.cpp
+++ b/src/RtcDateTime.cpp
@@ -1,5 +1,5 @@
 
-#if defined(ESP8266)
+#if defined(ESP8266) || defined(ESP32)
 #include <pgmspace.h>
 #else
 #include <avr/pgmspace.h>
@@ -20,7 +20,7 @@ RtcDateTime::RtcDateTime(uint32_t secondsFrom2000)
 uint8_t StringToUint8(const char* pString)
 {
     uint8_t value = 0;
-    
+
     // skip leading 0 and spaces
     while ('0' == *pString || *pString == ' ')
     {

--- a/src/RtcDateTime.h
+++ b/src/RtcDateTime.h
@@ -3,6 +3,11 @@
 #ifndef __RTCDATETIME_H__
 #define __RTCDATETIME_H__
 
+// ESP32 complains if not included
+#if defined(ESP32)
+#include <inttypes.h>
+#endif
+
 const uint16_t c_OriginYear = 2000;
 const uint32_t c_Epoch32OfOriginYear = 946684800;
 extern const uint8_t c_daysInMonth[] PROGMEM;

--- a/src/RtcDateTime.h
+++ b/src/RtcDateTime.h
@@ -11,11 +11,11 @@ class RtcDateTime
 {
 public:
     RtcDateTime(uint32_t secondsFrom2000 = 0);
-    RtcDateTime(uint16_t year, 
+    RtcDateTime(uint16_t year,
             uint8_t month,
             uint8_t dayOfMonth,
-            uint8_t hour, 
-            uint8_t minute, 
+            uint8_t hour,
+            uint8_t minute,
             uint8_t second) :
             _yearFrom2000((year >= c_OriginYear) ? year - c_OriginYear : year),
             _month(month),
@@ -66,10 +66,17 @@ public:
         *this = after;
     }
 
+    // remove seconds
+    void operator -= (uint32_t seconds)
+    {
+        RtcDateTime before = RtcDateTime( TotalSeconds() - seconds );
+        *this = before;
+    }
+
     // allows for comparisons to just work (==, <, >, <=, >=, !=)
-    operator uint32_t() const 
-    { 
-        return TotalSeconds(); 
+    operator uint32_t() const
+    {
+        return TotalSeconds();
     }
 
     // Epoch32 support

--- a/src/RtcUtility.cpp
+++ b/src/RtcUtility.cpp
@@ -1,7 +1,7 @@
 
 #include <Arduino.h>
 
-#if defined(ESP8266)
+#if defined(ESP8266) || defined(ESP32)
 #include <pgmspace.h>
 #else
 #include <avr/pgmspace.h>
@@ -38,4 +38,3 @@ uint8_t BcdToBin24Hour(uint8_t bcdHour)
     }
     return hour;
 }
-

--- a/src/RtcUtility.h
+++ b/src/RtcUtility.h
@@ -2,6 +2,11 @@
 #ifndef __RTCUTILITY_H__
 #define __RTCUTILITY_H__
 
+// ESP32 complains if not included
+#if defined(ESP32)
+#include <inttypes.h>
+#endif
+
 // for some reason, the DUE board support does not define this, even though other non AVR archs do
 #ifndef _BV
 #define _BV(b) (1UL << (b))


### PR DESCRIPTION
Simple and stupid condition on ESP32 definition for `pgmspace.h` inclusion. Minus operator to be able to get seconds difference between two `RtcDateTime` objects easily.