### PR TITLE
added support for non-default pins for i2c on esp32

### DIFF
--- a/src/RtcDS1302.h
+++ b/src/RtcDS1302.h
@@ -66,6 +66,12 @@ public:
         _wire.begin();
     }
 
+    
+    void Begin(int sda, int scl)
+    {
+        _wire.begin(sda, scl);
+    }
+
     bool GetIsWriteProtected()
     {
         uint8_t wp = getReg(DS1302_REG_WP);

--- a/src/RtcDS1307.h
+++ b/src/RtcDS1307.h
@@ -53,6 +53,10 @@ public:
     {
         _wire.begin();
     }
+    void Begin(int sda, int scl)
+    {
+        _wire.begin(sda, scl);
+    }
 
     uint8_t LastError()
     {

--- a/src/RtcDS3231.h
+++ b/src/RtcDS3231.h
@@ -234,6 +234,11 @@ public:
         _wire.begin();
     }
 
+    void Begin(int sda, int scl)
+    {
+        _wire.begin(sda, scl);
+    }
+
     uint8_t LastError()
     {
         return _lastError;
@@ -344,7 +349,7 @@ public:
         }
 
         // Temperature is represented as a 10-bit code with a resolution
-        // of 1/4th °C and is accessable as a signed 16-bit integer at
+        // of 1/4th ï¿½C and is accessable as a signed 16-bit integer at
         // locations 11h and 12h.
         //
         //       |         r11h          | DP |         r12h         |
@@ -354,7 +359,7 @@ public:
         // As it takes (8) right-shifts to register the decimal point (DP) to
         // the right of the 0th bit, the overall word scaling equals 256.
         //
-        // For example, at +/- 25.25°C, concatenated registers <r11h:r12h> =
+        // For example, at +/- 25.25ï¿½C, concatenated registers <r11h:r12h> =
         // 256 * (+/- 25+(1/4)) = +/- 6464, or 1940h / E6C0h.
 
         _wire.requestFrom(DS3231_ADDRESS, DS3231_REG_TEMP_SIZE);

--- a/src/RtcDS3231.h
+++ b/src/RtcDS3231.h
@@ -349,7 +349,7 @@ public:
         }
 
         // Temperature is represented as a 10-bit code with a resolution
-        // of 1/4th �C and is accessable as a signed 16-bit integer at
+        // of 1/4th °C and is accessable as a signed 16-bit integer at
         // locations 11h and 12h.
         //
         //       |         r11h          | DP |         r12h         |
@@ -359,7 +359,7 @@ public:
         // As it takes (8) right-shifts to register the decimal point (DP) to
         // the right of the 0th bit, the overall word scaling equals 256.
         //
-        // For example, at +/- 25.25�C, concatenated registers <r11h:r12h> =
+        // For example, at +/- 25.25°C, concatenated registers <r11h:r12h> =
         // 256 * (+/- 25+(1/4)) = +/- 6464, or 1940h / E6C0h.
 
         _wire.requestFrom(DS3231_ADDRESS, DS3231_REG_TEMP_SIZE);


### PR DESCRIPTION
Hi, I added this mostly for my own project but thought it would be cool to have it in the library as well.
On the other hand it is board specific, since stndard avr boards have i2c pins non-movable, maybe adding a "#ifdef" to allow this feature only on esp32, however, I am not sure how to do that.