### PR TITLE
Update RtcDS1302.h

### DIFF
--- a/src/RtcDS1302.h
+++ b/src/RtcDS1302.h
@@ -6,6 +6,7 @@
 #include <Arduino.h>
 #include "RtcDateTime.h"
 #include "RtcUtility.h"
+#include "ThreeWire.h"
 
 
 


### PR DESCRIPTION
Including RtcDS1302.h in a Platform.io project (using .ccp files) results in the following error: 'THREEWIRE_READFLAG' was not declared in this scope
This should fix that issue, but not impact it's use with Arduino IDE (using .ino files) projects.