### PR TITLE
[bugfix] Fix use-after-free memory corruption of RtcAlarmManager objects

### DIFF
--- a/src/RtcAlarmManager.h
+++ b/src/RtcAlarmManager.h
@@ -69,6 +69,27 @@ public:
         _alarms = new Alarm[_alarmsCount];
     }
 
+	RtcAlarmManager(const RtcAlarmManager& source) :
+        _alarmsCount(source._alarmsCount), _seconds(source._seconds)
+    {
+        _alarms = new Alarm[_alarmsCount];
+		memcpy(_alarms, source._alarms, _alarmsCount * sizeof(Alarm));
+    }
+
+	RtcAlarmManager& operator=(const RtcAlarmManager& source)
+    {
+		if (this == &source) return *this;
+		
+        _alarmsCount = source._alarmsCount;
+		_seconds = source._seconds;
+
+		delete[] _alarms;
+        _alarms = new Alarm[_alarmsCount];
+		memcpy(_alarms, source._alarms, _alarmsCount * sizeof(Alarm));
+		
+		return *this;
+    }
+
     ~RtcAlarmManager()
     {
         delete[] _alarms;

--- a/src/RtcAlarmManager.h
+++ b/src/RtcAlarmManager.h
@@ -73,22 +73,22 @@ public:
         _alarmsCount(source._alarmsCount), _seconds(source._seconds)
     {
         _alarms = new Alarm[_alarmsCount];
-		memcpy(_alarms, source._alarms, _alarmsCount * sizeof(Alarm));
+        memcpy(_alarms, source._alarms, _alarmsCount * sizeof(Alarm));
     }
 
 	RtcAlarmManager& operator=(const RtcAlarmManager& source)
     {
-		if (this == &source) return *this;
+        if (this == &source) return *this;
 		
         _alarmsCount = source._alarmsCount;
-		_seconds = source._seconds;
+        _seconds = source._seconds;
 
-		delete[] _alarms;
+        delete[] _alarms;
         _alarms = new Alarm[_alarmsCount];
-		memcpy(_alarms, source._alarms, _alarmsCount * sizeof(Alarm));
-		
-		return *this;
-    }
+        memcpy(_alarms, source._alarms, _alarmsCount * sizeof(Alarm));
+
+        return *this;
+     }
 
     ~RtcAlarmManager()
     {

--- a/src/RtcAlarmManager.h
+++ b/src/RtcAlarmManager.h
@@ -69,14 +69,14 @@ public:
         _alarms = new Alarm[_alarmsCount];
     }
 
-	RtcAlarmManager(const RtcAlarmManager& source) :
+    RtcAlarmManager(const RtcAlarmManager& source) :
         _alarmsCount(source._alarmsCount), _seconds(source._seconds)
     {
         _alarms = new Alarm[_alarmsCount];
         memcpy(_alarms, source._alarms, _alarmsCount * sizeof(Alarm));
     }
 
-	RtcAlarmManager& operator=(const RtcAlarmManager& source)
+    RtcAlarmManager& operator=(const RtcAlarmManager& source)
     {
         if (this == &source) return *this;
 		


### PR DESCRIPTION
Because this class uses dynamic memory allocation for the _alarms variable, the default copy constructor and assignment operators would cause copy of the reference only, not the data itself. This solves the issue by copying the data on new allocated memory.

Unwanted symptoms by this bug
- The memory this reference points to may be freed by the source object later on, and the overwritten by something else as it's now free memory. Use-after-free and data corruption.
- Modification of _alarms in either the source or the destination object will reflect a change in the other. Data corruption.

How to replicate and verify this bug:
```
RtcAlarmManager<callback> destination = RtcAlarmManager<callback>(1);
// print the value of the _alarms pointer and compare, _alarms needs to be made public
// Serial.printf("%p == %p", destination._alarms, source._alarms);
```