### PR TITLE
Fix enum-enum conversion warning in RtcDS1302.h

### DIFF
--- a/src/RtcDS1302.h
+++ b/src/RtcDS1302.h
@@ -44,7 +44,7 @@ const uint8_t DS1302RamSize = 31;
 
 
 // DS1302 Trickle Charge Control Register Bits
-enum DS1302TcrResistor 
+enum DS1302TcrResistor : uint8_t
 {
     DS1302TcrResistor_Disabled = 0,
     DS1302TcrResistor_2KOhm = 0b00000001,
@@ -53,7 +53,7 @@ enum DS1302TcrResistor
     DS1302TcrResistor_MASK  = 0b00000011,
 };
 
-enum DS1302TcrDiodes 
+enum DS1302TcrDiodes : uint8_t
 {
     DS1302TcrDiodes_None = 0,
     DS1302TcrDiodes_One      = 0b00000100,
@@ -62,14 +62,16 @@ enum DS1302TcrDiodes
     DS1302TcrDiodes_MASK     = 0b00001100,
 };
 
-enum DS1302TcrStatus 
+enum DS1302TcrStatus : uint8_t
 {
     DS1302TcrStatus_Enabled  = 0b10100000,
     DS1302TcrStatus_Disabled = 0b01010000,
     DS1302TcrStatus_MASK     = 0b11110000,
 };
 
-const uint8_t DS1302Tcr_Disabled = DS1302TcrStatus_Disabled | DS1302TcrDiodes_Disabled | DS1302TcrResistor_Disabled;
+const uint8_t DS1302Tcr_Disabled = static_cast<uint8_t>(DS1302TcrStatus_Disabled) | 
+                                   static_cast<uint8_t>(DS1302TcrDiodes_Disabled) | 
+                                   static_cast<uint8_t>(DS1302TcrResistor_Disabled);
 
 // DS1302 Clock Halt Register & Bits
 const uint8_t DS1302_REG_CH = 0x80; // bit in the seconds register


### PR DESCRIPTION
RtcDS1302.h was generating a deprecation warning due to bit-wise operations between different enumeration types. Specifically, the warning was:
"bit-wise operation between different enumeration types 'DS1302TcrStatus' and 'DS1302TcrDiodes' is deprecated"

Solution:
1. Modified the enum definiions to explicitly use uint8_t as their underlying type:
   - DS1302TcrResistor
   - DS1302TcrDiodes
   - DS1302TcrStatus

2. Updated the DS1302Tcr_Disabled constant definition to use static_cast<uint8_t>() for eac enum value:
   ```cpp
   const uint8_t DS1302Tcr_Disabled = static_cast<uint8_t>(DS1302TcrStatus_Disabled) | 
                                      static_cast<uint8_t>(DS1302TcrDiodes_Disabled) | 
                                      static_cast<uint8_t>(DS1302TcrResistor_Disabled);
                                      